### PR TITLE
Fixing unhandled exception when calling channel.Open() with no network connection

### DIFF
--- a/src/WampSharp/Auxiliary/Client/IWampClientConnectionMonitor.cs
+++ b/src/WampSharp/Auxiliary/Client/IWampClientConnectionMonitor.cs
@@ -8,5 +8,6 @@ namespace WampSharp.Auxiliary.Client
         
         event EventHandler<WampConnectionEstablishedEventArgs> ConnectionEstablished;
         event EventHandler ConnectionLost;
+        event EventHandler<WampConnectionErrorEventArgs> ConnectionError;
     }
 }

--- a/src/WampSharp/Auxiliary/Client/WampConnectionErrorEventArgs.cs
+++ b/src/WampSharp/Auxiliary/Client/WampConnectionErrorEventArgs.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace WampSharp.Auxiliary.Client
+{
+    public class WampConnectionErrorEventArgs : EventArgs
+    {
+        private readonly Exception mException;
+
+        public WampConnectionErrorEventArgs(Exception exception)
+        {
+            mException = exception;
+        }
+
+        public Exception Exception
+        {
+            get
+            {
+                return mException;
+            }
+        }
+    }
+}

--- a/src/WampSharp/WampSharp.csproj
+++ b/src/WampSharp/WampSharp.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Auxiliary\Client\IWampClientConnectionMonitor.cs" />
     <Compile Include="Auxiliary\Client\WampAuxiliaryClientFactory.cs" />
     <Compile Include="Auxiliary\Client\WampClientConnectionMonitor.cs" />
+    <Compile Include="Auxiliary\Client\WampConnectionErrorEventArgs.cs" />
     <Compile Include="Auxiliary\Client\WampConnectionEstablishedEventArgs.cs" />
     <Compile Include="Auxiliary\Server\WampAuxiliaryServer.cs" />
     <Compile Include="Core\Client\IWampServerProxyBuilder.cs" />


### PR DESCRIPTION
- Subscribing to OnError event handler to fix unhandled exception when calling channel.Open() and network connection is not available.
- Adding ConnectionError event.
- Completing connect task on ConnectionEstablished and ConnectionError event.
