### PR TITLE
Exceptions are propagated through the WebSocket4NetConnection

### DIFF
--- a/src/WampSharp.Default/WebSocket4Net/WebSocket4NetConnection.cs
+++ b/src/WampSharp.Default/WebSocket4Net/WebSocket4NetConnection.cs
@@ -68,7 +68,7 @@ namespace WampSharp.WebSocket4Net
 
         public void OnError(Exception error)
         {
-            // No can do.
+            mSubject.OnError(error);
         }
 
         public void OnCompleted()


### PR DESCRIPTION
When the websocket stops getting 'pongs' back, it will throw an exception. When this happened, the subscribers to the websocket were not notified and thought that everything is ok. 

WebSocket4Net Reference:
https://github.com/kerryjiang/WebSocket4Net/blob/master/WebSocket4Net/WebSocket.cs#L392
