### PR TITLE
Update WampRawTopicContainer.cs

### DIFF
--- a/src/net45/WampSharp/WAMP2/V2/PubSub/WampRawTopicContainer.cs
+++ b/src/net45/WampSharp/WAMP2/V2/PubSub/WampRawTopicContainer.cs
@@ -96,8 +96,9 @@ namespace WampSharp.V2.PubSub
                 {
                     if (!rawTopic.HasSubscribers)
                     {
-                        mSubscriptionIdToTopic.TryRemove(rawTopic.SubscriptionId, out rawTopic);
-                        mTopicUriToTopic.TryRemove(rawTopic.CustomizedSubscriptionId, out rawTopic);
+                        WampRawTopic<TMessage> rawTopicIgnore;
+                        mSubscriptionIdToTopic.TryRemove(rawTopic.SubscriptionId, out rawTopicIgnore); // "out rawTopic" makes it null in some cases
+                        mTopicUriToTopic.TryRemove(rawTopic.CustomizedSubscriptionId, out rawTopicIgnore); // "out rawTopic" makes it null in some cases
                         rawTopic.Dispose();
                     }
                 }


### PR DESCRIPTION
To fix NullRefExcp in OnTopicEmpty

---> (Inner Exception #0) System.NullReferenceException: Object reference not set to an instance of an object.
   at WampSharp.V2.PubSub.WampRawTopicContainer`1.OnTopicEmpty(Object sender, EventArgs e)
   at WampSharp.V2.PubSub.WampRawTopic`1.RaiseTopicEmpty()
   at WampSharp.V2.PubSub.WampRawTopic`1.Unsubscribe(IUnsubscribeRequest`1 request)
   at WampSharp.V2.PubSub.WampRawTopic`1.Subscription.OnConnectionClosed(Object sender, EventArgs e)
   at System.EventHandler.Invoke(Object sender, EventArgs e)
   at WampSharp.Core.Listener.WampConnectionMonitor`1.RaiseConnectionClosed(Object client, EventArgs empty)
   at WampSharp.Core.Listener.WampConnectionMonitor`1.OnConnectionClosed()
   at WampSharp.Core.Listener.WampConnectionMonitor`1.OnConnectionClosed(Object sender, EventArgs e)
   at System.EventHandler.Invoke(Object sender, EventArgs e)
   at WampSharp.Core.Listener.AsyncWampConnection`1.RaiseConnectionClosed()
   at WampSharp.Fleck.FleckWampConnection`1.OnConnectionClose()
   at Fleck.WebSocketConnection.CloseSocket()
   at Fleck.WebSocketConnection.<>c__DisplayClass13.<SendBytes>b__11()
   at Fleck.SocketWrapper.<>c__DisplayClass1e.<Send>b__18(Task t)
   at System.Threading.Tasks.ContinuationTaskFromTask.InnerInvoke()
   at System.Threading.Tasks.Task.Execute()<---*/