### PR TITLE
Resolve Issue #95 - Allow WebSocket4Net error to propagate to caller, cancel outstanding RPC calls on connection issue.

### DIFF
--- a/src/net45/Default/WampSharp.WebSocket4Net/WebSocket4Net/WebSocket4NetConnection.cs
+++ b/src/net45/Default/WampSharp.WebSocket4Net/WebSocket4Net/WebSocket4NetConnection.cs
@@ -77,13 +77,7 @@ namespace WampSharp.WebSocket4Net
 
         void IWampConnection<TMessage>.Send(WampMessage<object> message)
         {
-            try
-            {
-                Send(message);
-            }
-            catch (Exception ex)
-            {
-            }
+            Send(message);
         }
 
         public abstract void Send(WampMessage<object> message);

--- a/src/net45/Samples/WAMP1/WampSharp.CraClientSample/Program.cs
+++ b/src/net45/Samples/WAMP1/WampSharp.CraClientSample/Program.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using WampSharp.Core.Cra;
 using WampSharp.Core.Serialization;
@@ -23,9 +24,10 @@ namespace WampSharp.CraClientSample
         static void Main(string[] args)
         {
             //Sample modeled and compatible with Autobahn Python https://github.com/tavendo/AutobahnPython [examples/twisted/wamp1/authentication/client.py]
-         
-            JsonFormatter formatter = new JsonFormatter();
-            DefaultWampChannelFactory channelFactory = new DefaultWampChannelFactory(formatter);
+
+            JsonSerializer serializer = new JsonSerializer();
+            JsonFormatter formatter = new JsonFormatter(serializer);
+            DefaultWampChannelFactory channelFactory = new DefaultWampChannelFactory(serializer);
             IWampChannel<JToken> channel = channelFactory.CreateChannel("ws://127.0.0.1:9000/");
 
             channel.Open();

--- a/src/net45/WampSharp.WAMP1.Default/WAMP1/V1/DefaultWampChannelFactory.cs
+++ b/src/net45/WampSharp.WAMP1.Default/WAMP1/V1/DefaultWampChannelFactory.cs
@@ -20,7 +20,7 @@ namespace WampSharp.V1
             mSerializer = serializer;
         }
 
-        public DefaultWampChannelFactory(IWampFormatter<JToken> formatter)
+        private DefaultWampChannelFactory(IWampFormatter<JToken> formatter)
             : base(formatter)
         {
         }

--- a/src/net45/WampSharp.WAMP1/WAMP1/V1/Rpc/Client/WampRpcClientHandler.cs
+++ b/src/net45/WampSharp.WAMP1/WAMP1/V1/Rpc/Client/WampRpcClientHandler.cs
@@ -30,6 +30,27 @@ namespace WampSharp.V1.Rpc.Client
         {
             mFormatter = formatter;
             mServerProxy = serverProxyFactory.Create(new RpcWampClient(this), connection);
+
+            connection.ConnectionClosed += Connection_ConnectionClosed;
+            connection.ConnectionError += Connection_ConnectionError;
+        }
+
+        private void Connection_ConnectionError(object sender, WampConnectionErrorEventArgs e)
+        {
+            HandleConnectionIssue("Connection Error");
+        }
+
+        private void Connection_ConnectionClosed(object sender, EventArgs e)
+        {
+            HandleConnectionIssue("Connection Closed");
+        }
+
+        private void HandleConnectionIssue(string errorDesc)
+        {
+            foreach (var kvp in mCallIdToSubject)
+            {
+                ErrorArrived(kvp.Key, "http://api.wamp.ws/error#generic", errorDesc);
+            }
         }
 
         public object Handle(WampRpcCall rpcCall)


### PR DESCRIPTION
Resolve Issue #95 - remove catch from WampSharp.WebSocket4Net.WebSocket4NetConnection.Send() to allow error to propagate to caller.

WampSharp.V1.Rpc.Client.WampRpcClientHandler<TMessage> - hook ConnectionClosed and ConnectionError events and cancel outstanding RPC calls.