### PR TITLE
Composite prefixed nested operations & properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ WampSharp
 
 A C# implementation of [WAMP (The Web Application Messaging Protocol)][WampLink]
 
-The implementation supports WAMPv2 and includes both Json and MsgPack support, and both Router (Broker and Dealer roles) and Client (Publisher/Subscriber and Callee/Caller) roles.
+The implementation supports WAMPv2 and includes both Json and MsgPack support, and both Router (Broker and Dealer roles) and Client (Publisher/Subscriber and Callee/Caller) roles. See here for a list of [implemented advanced profile features](https://github.com/Code-Sharp/WampSharp-docs#advanced-profile-features).
 
 The implementation also supports WAMPv1, both client and server roles.
 
@@ -12,47 +12,35 @@ The implementation also supports WAMPv1, both client and server roles.
 
 Master | Provider
 ------ | --------
-[![Build Status][WinImgMaster]][WinLinkMaster] | Windows CI Provided By [CodeBetter][] and [JetBrains][] 
-[![Build Status][MonoImgMaster]][MonoLinkMaster] | Mono CI Provided by [travis-ci][] 
+[![Build Status][WinImgMaster]][WinLinkMaster] | Windows CI Provided By [CodeBetter][] and [JetBrains][]
+[![Build Status][AppVeyorImgMaster]][AppVeyorLinkMaster] | Windows CI Provided By [AppVeyor][]
+[![Build Status][MonoImgMaster]][MonoLinkMaster] | Mono CI Provided by [travis-ci][]
 
+## Documentation
 
-## Advanced profile supported features:
+Documentation has moved to [its own repository](https://github.com/Code-Sharp/WampSharp-docs)!
 
-The following [Advanced profile features](https://github.com/wamp-proto/wamp-proto/blob/master/spec/advanced.md) are supported
+## WampSharp v1.2.3.12-beta
 
-* [Progressive call results](https://github.com/wamp-proto/wamp-proto/blob/master/spec/advanced/progressive-call-results.md): [[caller tutorial|Caller role#progressive-calls]] | [[callee tutorial|Callee role#progressive-callee]]
-* [Caller identification](https://github.com/wamp-proto/wamp-proto/blob/master/spec/advanced/caller-identification.md): [[caller tutorial|Caller-role#caller-identification]] | [[callee tutorial|Callee-role#caller-identification]]
-* [Session meta api](https://github.com/wamp-proto/wamp-proto/blob/master/spec/advanced/session-meta-api.md), [Registration meta api](https://github.com/wamp-proto/wamp-proto/blob/master/spec/advanced/registration-meta-api.md), [Subscription meta api](https://github.com/wamp-proto/wamp-proto/blob/master/spec/advanced/subscription-meta-api.md)
-* [Shared registrations](https://github.com/wamp-proto/wamp-proto/blob/master/spec/advanced/shared-registration.md), see also [here](http://crossbar.io/docs/Shared-Registrations/)
-* [Subscriber black and whitelisting](https://github.com/wamp-proto/wamp-proto/blob/master/spec/advanced/subscriber-blackwhite-listing.md)
-* [Publisher exclusion](https://github.com/wamp-proto/wamp-proto/blob/master/spec/advanced/publisher-exclusion.md)
-* [Publisher identification](https://github.com/wamp-proto/wamp-proto/blob/master/spec/advanced/publisher-identification.md)
-* [Pattern-based subscriptions](https://github.com/wamp-proto/wamp-proto/blob/master/spec/advanced/pattern-based-subscription.md) - see also [here](http://crossbar.io/docs/Pattern-Based-Subscriptions/)
-* [Pattern-based registrations](https://github.com/wamp-proto/wamp-proto/blob/master/spec/advanced/pattern-based-registration.md) - see also [here](http://crossbar.io/docs/Pattern-Based-Registrations/)
-* [RawSocket transport](https://github.com/wamp-proto/wamp-proto/blob/master/spec/advanced/rawsocket-transport.md)
-* [Authentication](https://github.com/wamp-proto/wamp-proto/blob/master/spec/advanced/authentication.md)
-* [WAMP-CRA](https://github.com/wamp-proto/wamp-proto/blob/master/spec/advanced/challenge-response-authentication.md)
-
-## WampSharp v1.2.1.6-beta
-
-WampSharp v1.2.1.6-beta released, see version [release notes](https://github.com/Code-Sharp/WampSharp/wiki/WampSharp-v1.2.1.6-beta-release-notes).
+WampSharp v1.2.3.12-beta released, see version [release notes](https://github.com/Code-Sharp/WampSharp-docs/blob/master/Release-notes/WampSharp-v1.2.3.12-beta-release-notes.md).
 
 ## Get Started
 
-See [Get started tutorial](https://github.com/Code-Sharp/WampSharp/wiki/Getting-started-with-WAMPv2) and
-* [Getting started with Callee](https://github.com/Code-Sharp/WampSharp/wiki/Getting-Started-with-Callee)
-* [Getting started with Caller](https://github.com/Code-Sharp/WampSharp/wiki/Getting-Started-with-Caller)
-* [Getting started with Subscriber](https://github.com/Code-Sharp/WampSharp/wiki/Getting-Started-with-Subscriber)
-* [Getting started with Publisher](https://github.com/Code-Sharp/WampSharp/wiki/Getting-Started-with-Publisher)
+See [Get started tutorial](https://github.com/Code-Sharp/WampSharp-docs/blob/master/WAMP2/Getting-started-with-WAMPv2.md) and
+* [Getting started with Callee](https://github.com/Code-Sharp/WampSharp-docs/blob/master/WAMP2/Roles/Callee/Getting-Started-with-Callee.md)
+* [Getting started with Caller](https://github.com/Code-Sharp/WampSharp-docs/blob/master/WAMP2/Roles/Caller/Getting-Started-with-Caller.md)
+* [Getting started with Publisher](https://github.com/Code-Sharp/WampSharp-docs/blob/master/WAMP2/Roles/Publisher/Getting-Started-with-Publisher.md)
+* [Getting started with Subscriber](https://github.com/Code-Sharp/WampSharp-docs/blob/master/WAMP2/Roles/Subscriber/Getting-Started-with-Subscriber.md)
 
-See [Wiki documentation](https://github.com/Code-Sharp/WampSharp/wiki) for more help.
-
+See [documentation](https://github.com/Code-Sharp/WampSharp-docs) for more help.
 
 ## WAMPv1 support
 
-WAMPv1 support is still available. You can read about it at the [Wiki](https://github.com/Code-Sharp/WampSharp/wiki).
+WAMPv1 support is still available. You can read about it at the [Documentation site](https://github.com/Code-Sharp/WampSharp-docs).
 
-If you're updating from a previous WampSharp version and you're not interested yet in updating your application to WAMPv2, please read the following [notes](https://github.com/Code-Sharp/WampSharp/wiki/Notes-for-WAMPv1-users).
+In order to use it, Install WampSharp.WAMP1.Default from NuGet.
+
+If you're updating from a previous WampSharp version and you're not interested yet in updating your application to WAMPv2, please read the following [notes](https://github.com/Code-Sharp/WampSharp-docs/blob/master/WAMP1/Notes-for-WAMPv1-users.md).
 
 ## Donations
 
@@ -62,10 +50,14 @@ Your donations help keep this project development alive.
 
 [WampLink]:http://wamp.ws
 
-[WinImgMaster]:http://teamcity.codebetter.com/app/rest/builds/buildType:\(id:WampSharp_Dev_Build\)/statusIcon
-[WinLinkMaster]:http://teamcity.codebetter.com/project.html?projectId=WampSharp_Dev&guest=1
-[MonoImgMaster]:https://travis-ci.org/Code-Sharp/WampSharp.png?branch=develop
+[NuGetImgMaster]:http://img.shields.io/nuget/v/WampSharp.Default.svg
+[NuGetLinkMaster]:http://www.nuget.org/packages/WampSharp.Default/
+[WinImgMaster]:https://img.shields.io/teamcity/codebetter/WampSharp_Wampv2_Build.svg
+[WinLinkMaster]:http://teamcity.codebetter.com/project.html?projectId=WampSharp_Wampv2&guest=1
+[MonoImgMaster]:https://img.shields.io/travis/Code-Sharp/WampSharp/wampv2.svg
 [MonoLinkMaster]:https://travis-ci.org/Code-Sharp/WampSharp
+[AppVeyorLinkMaster]:https://ci.appveyor.com/project/darkl/wampsharp-759
+[AppVeyorImgMaster]:https://ci.appveyor.com/api/projects/status/fgbqbgwqx4j8jain
 
 [JetBrains]:http://www.jetbrains.com/
 [CodeBetter]:http://codebetter.com/

--- a/src/mono/WampSharp/WampSharp.csproj
+++ b/src/mono/WampSharp/WampSharp.csproj
@@ -779,6 +779,9 @@
     <Compile Include="..\..\net45\WampSharp\WAMP2\V2\MetaApi\PubSub\SubscriptionDetailsExtended.cs">
       <Link>WAMP2\V2\MetaApi\PubSub\SubscriptionDetailsExtended.cs</Link>
     </Compile>
+    <Compile Include="..\..\net45\WampSharp\WAMP2\V2\Rpc\Callee\LocalRpcInterfaceOperation.cs">
+      <Link>WAMP2\V2\Rpc\Callee\LocalRpcInterfaceOperation.cs</Link>
+    </Compile>
     <Compile Include="..\..\net45\WampSharp\WAMP2\V2\Rpc\Callee\Reflection\CalleeRegistrationInterceptor.cs">
       <Link>WAMP2\V2\Rpc\Callee\Reflection\CalleeRegistrationInterceptor.cs</Link>
     </Compile>

--- a/src/net40/WampSharp/WampSharp.csproj
+++ b/src/net40/WampSharp/WampSharp.csproj
@@ -783,6 +783,9 @@
     <Compile Include="..\..\net45\WampSharp\WAMP2\V2\MetaApi\PubSub\SubscriptionDetailsExtended.cs">
       <Link>WAMP2\V2\MetaApi\PubSub\SubscriptionDetailsExtended.cs</Link>
     </Compile>
+    <Compile Include="..\..\net45\WampSharp\WAMP2\V2\Rpc\Callee\LocalRpcInterfaceOperation.cs">
+      <Link>WAMP2\V2\Rpc\Callee\LocalRpcInterfaceOperation.cs</Link>
+    </Compile>
     <Compile Include="..\..\net45\WampSharp\WAMP2\V2\Rpc\Callee\Reflection\CalleeRegistrationInterceptor.cs">
       <Link>WAMP2\V2\Rpc\Callee\Reflection\CalleeRegistrationInterceptor.cs</Link>
     </Compile>

--- a/src/net45/Tests/WampSharp.Tests.Wampv2/Integration/RpcInterfaceTests.cs
+++ b/src/net45/Tests/WampSharp.Tests.Wampv2/Integration/RpcInterfaceTests.cs
@@ -1,0 +1,205 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using SystemEx;
+using NUnit.Framework;
+using System.Threading.Tasks;
+using WampSharp.Core.Serialization;
+using WampSharp.Tests.Wampv2.TestHelpers.Integration;
+using WampSharp.V2;
+using WampSharp.V2.Client;
+using WampSharp.V2.Core.Contracts;
+using WampSharp.V2.Rpc;
+using WampSharp.WAMP2.V2.Rpc.Callee;
+
+namespace WampSharp.Tests.Wampv2.Integration
+{
+    public class RpcInterfaceTests
+    {
+        [Test]
+        public async Task RpcInterfaceTest()
+        {
+            WampPlayground playground = new WampPlayground();
+            playground.Host.Open();
+
+            IWampChannel calleeChannel = playground.CreateNewChannel("realm1");
+            await calleeChannel.Open();
+
+            var instance = new TestCompositeService();
+
+            IWampRealmProxy realm = calleeChannel.RealmProxy;
+
+            //Task<IAsyncDisposable> registrationTask1 = realm.Services.RegisterCallee(instance);
+
+            //await registrationTask1;
+
+            var operation = new LocalRpcInterfaceOperation(new TestCompositeService(), "com.test.instance.124");
+
+
+            Task<IAsyncDisposable> registrationTask2 =
+                calleeChannel.RealmProxy.RpcCatalog.Register(operation,
+                                                   new RegisterOptions()
+                                                   {
+                                                       Match = WampMatchPattern.Prefix
+                                                   });
+
+            await registrationTask2;
+
+            IWampChannel callerChannel = playground.CreateNewChannel("realm1");
+            await callerChannel.Open();
+
+            var callback = new MyCallback();
+
+            callerChannel.RealmProxy.RpcCatalog.Invoke
+                (callback, new CallOptions(), "com.test.instance.124.appliance.isTeapot");
+
+            Assert.That(callback.Called, Is.EqualTo(true));
+        }
+
+        protected class MyCallback : IWampRawRpcOperationClientCallback
+        {
+            public bool Called
+            {
+                get;
+                private set;
+            }
+
+            public virtual void Result<TMessage>(IWampFormatter<TMessage> formatter, ResultDetails details)
+            {
+                Called = true;
+            }
+
+            public virtual void Result<TMessage>(IWampFormatter<TMessage> formatter, ResultDetails details, TMessage[] arguments)
+            {
+            }
+
+            public virtual void Result<TMessage>(IWampFormatter<TMessage> formatter, ResultDetails details, TMessage[] arguments,
+                                                 IDictionary<string, TMessage> argumentsKeywords)
+            {
+            }
+
+            public virtual void Error<TMessage>(IWampFormatter<TMessage> formatter, TMessage details, string error)
+            {
+            }
+
+            public virtual void Error<TMessage>(IWampFormatter<TMessage> formatter, TMessage details, string error, TMessage[] arguments)
+            {
+            }
+
+            public virtual void Error<TMessage>(IWampFormatter<TMessage> formatter, TMessage details, string error, TMessage[] arguments,
+                                                TMessage argumentsKeywords)
+            {
+            }
+        }
+    }
+
+    public interface IRpcTestSubService
+    {
+        [WampProcedure("progressiveTest")]
+        [WampProgressiveResultProcedure]
+        Task<string> progressiveResultsMethod(string param, IProgress<string> progress);
+
+        [WampProcedure("asyncTest")]
+        Task<string> asyncMethod(string param);
+
+        [WampProcedure("syncTest")]
+        string syncMethod(string param);
+
+    }
+    public interface IApplianceSubService
+    {
+        [WampProcedure("isTeapot")]
+        bool isTeapot();
+
+        [WampProcedure("boilWater")]
+        string boil(int amount);
+    }
+
+    public interface IRpcCompositeService
+    {
+        [WampProcedure("test")]
+        IRpcTestSubService GetTestSubService();
+
+        [WampProcedure("appliance")]
+        IApplianceSubService GetApplianceSubService();
+
+        [WampProcedure("version")]
+        string version();
+    }
+
+
+    public class TestCompositeService: IRpcCompositeService
+    {
+        private RpcTestSubService mTestSubService = new RpcTestSubService();
+        private ApplianceSubService mAppliance = new ApplianceSubService();
+
+        public IRpcTestSubService GetTestSubService()
+        {
+            return mTestSubService;
+        }
+
+        public IApplianceSubService GetApplianceSubService()
+        {
+            return mAppliance;
+        }
+
+        public string version()
+        {
+            return "0.1";
+        }
+    }
+
+    internal class ApplianceSubService : IApplianceSubService
+    {
+        public bool isTeapot()
+        {
+            return true;
+        }
+
+        public string boil(int amount)
+        {
+            return "Boiled " + amount;
+        }
+    }
+
+    internal class RpcTestSubService : IRpcTestSubService
+    {
+        public async Task<string> progressiveResultsMethod(string param, IProgress<string> progress)
+        {
+            Random rand = new Random(Guid.NewGuid().GetHashCode());
+            int count = rand.Next(40);
+            string value= null;
+            for (int i = 0; i < count; i++)
+            {
+                value = param + rand.Next();
+                //Don't return last result as intermediate progress
+                if (i < count)
+                {
+                    progress.Report(value);
+                    await Task.Delay(rand.Next(100, 1000));
+                }
+            }
+
+            return value;
+        }
+
+        public async Task<string> asyncMethod(string param)
+        {
+            Random rand = new Random(Guid.NewGuid().GetHashCode());
+            await Task.Delay(rand.Next(100, 1000));
+
+
+            return param + rand.Next();
+        }
+
+        public string syncMethod(string param)
+        {
+            Random rand = new Random(Guid.NewGuid().GetHashCode());
+            return param + rand.Next();
+        }
+    }
+
+
+
+}

--- a/src/net45/Tests/WampSharp.Tests.Wampv2/WampSharp.Tests.Wampv2.csproj
+++ b/src/net45/Tests/WampSharp.Tests.Wampv2/WampSharp.Tests.Wampv2.csproj
@@ -84,6 +84,7 @@
     <Compile Include="Integration\PatternRpcTests.cs" />
     <Compile Include="Integration\PublisherSubscriber.cs" />
     <Compile Include="Integration\PubSubReflectionTests.cs" />
+    <Compile Include="Integration\RpcInterfaceTests.cs" />
     <Compile Include="Integration\RpcOptionsTests.cs" />
     <Compile Include="Integration\RpcProgressTests.cs" />
     <Compile Include="Integration\RpcProxies\IArgumentsService.cs" />

--- a/src/net45/WampSharp/Core/Utilities/TypeExtensions.cs
+++ b/src/net45/WampSharp/Core/Utilities/TypeExtensions.cs
@@ -48,6 +48,15 @@ namespace System.Reflection
 #endif
         }
 
+        public static IEnumerable<MemberInfo> GetPublicInstanceMembers(this Type type)
+        {
+#if PCL
+            return type.GetTypeInfo().DeclaredMethods
+                .Where(x => x.IsPublic && !x.IsStatic);
+#else
+            return type.GetMembers(BindingFlags.Public | BindingFlags.Instance);
+#endif
+        }
         public static IEnumerable<MethodInfo> GetInstanceMethods(this Type type)
         {
 #if PCL

--- a/src/net45/WampSharp/WAMP2/V2/Api/CalleeProxy/CalleeProxyInterceptor.cs
+++ b/src/net45/WampSharp/WAMP2/V2/Api/CalleeProxy/CalleeProxyInterceptor.cs
@@ -47,7 +47,7 @@ namespace WampSharp.V2
                 throw new WampIncompatibleCalleeProxyMethodException(method);
             }
 
-            return attribute.Procedure;
+            return string.IsNullOrEmpty(attribute.Procedure) ? method.Name : attribute.Procedure;
         }
     }
 }

--- a/src/net45/WampSharp/WAMP2/V2/Rpc/Callee/LocalRpcInterfaceOperation.cs
+++ b/src/net45/WampSharp/WAMP2/V2/Rpc/Callee/LocalRpcInterfaceOperation.cs
@@ -169,6 +169,11 @@ namespace WampSharp.WAMP2.V2.Rpc.Callee
                 mPath = path;
             }
 
+            public bool IsCalleeProcedure(MethodInfo method)
+            {
+                return mOuterInterceptor.IsCalleeMember(method);
+            }
+
             public bool IsCalleeMember(MemberInfo member)
             {
                 return mOuterInterceptor.IsCalleeMember(member);

--- a/src/net45/WampSharp/WAMP2/V2/Rpc/Callee/LocalRpcInterfaceOperation.cs
+++ b/src/net45/WampSharp/WAMP2/V2/Rpc/Callee/LocalRpcInterfaceOperation.cs
@@ -167,17 +167,17 @@ namespace WampSharp.WAMP2.V2.Rpc.Callee
                 mPath = path;
             }
 
-            public bool IsCalleeProcedure(MethodInfo method)
+            public bool IsCalleeMember(MemberInfo member)
             {
-                return mOuterInterceptor.IsCalleeProcedure(method);
+                return mOuterInterceptor.IsCalleeMember(member);
             }
 
-            public RegisterOptions GetRegisterOptions(MethodInfo method)
+            public RegisterOptions GetRegisterOptions(MemberInfo method)
             {
                 return mOuterInterceptor.GetRegisterOptions(method);
             }
 
-            public string GetProcedureUri(MethodInfo method)
+            public string GetProcedureUri(MemberInfo method)
             {
                 return (String.IsNullOrEmpty(mPath) ? "" : mPath + ".") + mOuterInterceptor.GetProcedureUri(method);
             }

--- a/src/net45/WampSharp/WAMP2/V2/Rpc/Callee/LocalRpcInterfaceOperation.cs
+++ b/src/net45/WampSharp/WAMP2/V2/Rpc/Callee/LocalRpcInterfaceOperation.cs
@@ -1,0 +1,186 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Castle.Core.Internal;
+using WampSharp.Core.Serialization;
+using WampSharp.Logging;
+using WampSharp.V2;
+using WampSharp.V2.Core;
+using WampSharp.V2.Core.Contracts;
+using WampSharp.V2.Error;
+using WampSharp.V2.Rpc;
+
+namespace WampSharp.WAMP2.V2.Rpc.Callee
+{
+    public class LocalRpcInterfaceOperation: IWampRpcOperation
+    {
+        private readonly string mPrefix;
+        private readonly string mPath;
+        private readonly ILog mLogger;
+        private readonly Dictionary<string, OperationToRegister> mOperationMap =
+          new Dictionary<string, OperationToRegister>();
+        protected readonly static IWampFormatter<object> ObjectFormatter = WampObjectFormatter.Value;
+        private Func<object> mInstanceProvider;
+
+        public LocalRpcInterfaceOperation(object instance, string prefix) :
+            this(instance, String.Empty, prefix, CalleeRegistrationInterceptor.Default)
+        {
+        }
+
+        public LocalRpcInterfaceOperation(object instance, string prefix, ICalleeRegistrationInterceptor interceptor) : 
+            this(instance, String.Empty, prefix, interceptor) {
+        }
+
+        public LocalRpcInterfaceOperation(object instance, string path, string prefix, ICalleeRegistrationInterceptor interceptor) : this(instance.GetType(), () => instance, path, prefix, interceptor)
+        {
+
+        }
+
+        public LocalRpcInterfaceOperation(Type type, Func<object> instanceProvider, string prefix,
+            ICalleeRegistrationInterceptor interceptor)
+            : this(type, instanceProvider, String.Empty, prefix, interceptor)
+        {
+            
+        }
+
+        public LocalRpcInterfaceOperation(Type type, Func<object> instanceProvider, string path, string prefix, ICalleeRegistrationInterceptor interceptor)
+        {
+            mInstanceProvider = instanceProvider;
+            mPrefix = prefix;
+            mPath = path;
+            string fullPath = (String.IsNullOrEmpty(path) ? "" : path + ".") + prefix;
+            mLogger = LogProvider.GetLogger(typeof(LocalRpcInterfaceOperation) + "." + fullPath);
+
+            OperationExtractor extractor = new OperationExtractor();
+
+            ContextualizingCalleeRegistrationInterceptor contextualizingCalleeRegistrationInterceptor = new ContextualizingCalleeRegistrationInterceptor(interceptor, fullPath);
+            IEnumerable<OperationToRegister> operationsToRegister =
+                extractor.ExtractOperations(type, instanceProvider, contextualizingCalleeRegistrationInterceptor);
+
+            foreach (var operationMapRecord in operationsToRegister)
+            {
+                mOperationMap.Add(operationMapRecord.Operation.Procedure, operationMapRecord);
+            }
+        }
+
+        public void Invoke<TMessage>(IWampRawRpcOperationRouterCallback caller, IWampFormatter<TMessage> formatter,
+       InvocationDetails details)
+        {
+            InnerInvoke(caller, formatter, details, null, null);
+        }
+
+        public void Invoke<TMessage>(IWampRawRpcOperationRouterCallback caller, IWampFormatter<TMessage> formatter,
+            InvocationDetails details, TMessage[] arguments)
+        {
+            InnerInvoke(caller, formatter, details, arguments, null);
+        }
+
+        public void Invoke<TMessage>(IWampRawRpcOperationRouterCallback caller, IWampFormatter<TMessage> formatter,
+            InvocationDetails details, TMessage[] arguments, IDictionary<string, TMessage> argumentsKeywords)
+        {
+            InnerInvoke(caller, formatter, details, arguments, argumentsKeywords);
+        }
+
+        protected void InnerInvoke<TMessage>(IWampRawRpcOperationRouterCallback caller,
+            IWampFormatter<TMessage> formatter,
+            InvocationDetails details,
+            TMessage[] arguments,
+            IDictionary<string, TMessage> argumentsKeywords)
+        {
+            IWampRpcOperation operation = FindLongestMatch(details.Procedure);
+
+            if (operation != null)
+                operation.Invoke(caller, formatter, details, arguments, argumentsKeywords);
+            else
+            {
+                IWampErrorCallback callback = new WampRpcErrorCallback(caller);
+
+                WampRpcRuntimeException wampException =
+                    ConvertExceptionToRuntimeException(new NotSupportedException("Method not supported " + details.Procedure));
+                callback.Error(wampException);
+            }
+        }
+
+        private IWampRpcOperation FindLongestMatch(string procedure)
+        {
+            while (procedure.Length > mPrefix.Length)
+            {
+                OperationToRegister record;
+                if (mOperationMap.TryGetValue(procedure, out record))
+                {
+                    return record.Operation;
+                }
+                procedure = procedure.Substring(0, procedure.LastIndexOf('.'));
+            }
+            return null;
+        }
+
+        protected static WampRpcRuntimeException ConvertExceptionToRuntimeException(Exception exception)
+        {
+            return new WampRpcRuntimeException(exception.Message, exception);
+        }
+
+        protected class WampRpcErrorCallback : IWampErrorCallback
+        {
+            private readonly IWampRawRpcOperationRouterCallback mCallback;
+
+            public WampRpcErrorCallback(IWampRawRpcOperationRouterCallback callback)
+            {
+                mCallback = callback;
+            }
+
+            public void Error(object details, string error)
+            {
+                mCallback.Error(ObjectFormatter, details, error);
+            }
+
+            public void Error(object details, string error, object[] arguments)
+            {
+                mCallback.Error(ObjectFormatter, details, error, arguments);
+            }
+
+            public void Error(object details, string error, object[] arguments, object argumentsKeywords)
+            {
+                mCallback.Error(ObjectFormatter, details, error, arguments, argumentsKeywords);
+            }
+        }
+        public string Procedure
+        {
+            get { return mPrefix; }
+        }
+
+        protected class ContextualizingCalleeRegistrationInterceptor: ICalleeRegistrationInterceptor
+        {
+            private readonly ICalleeRegistrationInterceptor mOuterInterceptor;
+            private readonly string mPath;
+
+            public ContextualizingCalleeRegistrationInterceptor(ICalleeRegistrationInterceptor outerInterceptor, string path)
+            {
+                if (outerInterceptor is ContextualizingCalleeRegistrationInterceptor)
+                    mOuterInterceptor =
+                        (outerInterceptor as ContextualizingCalleeRegistrationInterceptor).mOuterInterceptor;
+                else
+                    mOuterInterceptor = outerInterceptor;
+                mPath = path;
+            }
+
+            public bool IsCalleeProcedure(MethodInfo method)
+            {
+                return mOuterInterceptor.IsCalleeProcedure(method);
+            }
+
+            public RegisterOptions GetRegisterOptions(MethodInfo method)
+            {
+                return mOuterInterceptor.GetRegisterOptions(method);
+            }
+
+            public string GetProcedureUri(MethodInfo method)
+            {
+                return (String.IsNullOrEmpty(mPath) ? "" : mPath + ".") + mOuterInterceptor.GetProcedureUri(method);
+            }
+        }
+    }
+}

--- a/src/net45/WampSharp/WAMP2/V2/Rpc/Callee/LocalRpcInterfaceOperation.cs
+++ b/src/net45/WampSharp/WAMP2/V2/Rpc/Callee/LocalRpcInterfaceOperation.cs
@@ -4,7 +4,9 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
+#if !PCL
 using Castle.Core.Internal;
+#endif
 using WampSharp.Core.Serialization;
 using WampSharp.Logging;
 using WampSharp.V2;

--- a/src/net45/WampSharp/WAMP2/V2/Rpc/Callee/Reflection/CalleeRegistrationInterceptor.cs
+++ b/src/net45/WampSharp/WAMP2/V2/Rpc/Callee/Reflection/CalleeRegistrationInterceptor.cs
@@ -1,5 +1,7 @@
 using System.Reflection;
+#if !PCL
 using Castle.Core.Internal;
+#endif
 using WampSharp.V2.Core.Contracts;
 using WampSharp.V2.Rpc;
 

--- a/src/net45/WampSharp/WAMP2/V2/Rpc/Callee/Reflection/CalleeRegistrationInterceptor.cs
+++ b/src/net45/WampSharp/WAMP2/V2/Rpc/Callee/Reflection/CalleeRegistrationInterceptor.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Reflection;
 #if !PCL
 using Castle.Core.Internal;
@@ -20,7 +21,15 @@ namespace WampSharp.V2
             mRegisterOptions = registerOptions;
         }
 
-        public bool IsCalleeMember(MemberInfo member)
+#if !PCL
+        [Obsolete("Deprecated.  Use IsCalleeMember for readonly property support")]
+#endif
+        public virtual bool IsCalleeProcedure(MethodInfo method)
+        {
+            return this.IsCalleeMember(method);
+        }
+
+        public virtual bool IsCalleeMember(MemberInfo member)
         {
             return member.IsDefined(typeof(WampMemberAttributeBase));
         }

--- a/src/net45/WampSharp/WAMP2/V2/Rpc/Callee/Reflection/CalleeRegistrationInterceptor.cs
+++ b/src/net45/WampSharp/WAMP2/V2/Rpc/Callee/Reflection/CalleeRegistrationInterceptor.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Castle.Core.Internal;
 using WampSharp.V2.Core.Contracts;
 using WampSharp.V2.Rpc;
 
@@ -17,24 +18,27 @@ namespace WampSharp.V2
             mRegisterOptions = registerOptions;
         }
 
-        public virtual bool IsCalleeProcedure(MethodInfo method)
+        public bool IsCalleeMember(MemberInfo member)
         {
-            return method.IsDefined(typeof (WampProcedureAttribute));
+            return member.IsDefined(typeof(WampMemberAttributeBase));
         }
 
-        public virtual RegisterOptions GetRegisterOptions(MethodInfo method)
+        public virtual RegisterOptions GetRegisterOptions(MemberInfo member)
         {
             RegisterOptions result = new RegisterOptions(mRegisterOptions);
 
             return result;
         }
 
-        public virtual string GetProcedureUri(MethodInfo method)
+        public virtual string GetProcedureUri(MemberInfo member)
         {
-            WampProcedureAttribute attribute =
-                method.GetCustomAttribute<WampProcedureAttribute>();
+            WampMemberAttributeBase attribute =
+                member.GetCustomAttribute<WampMemberAttributeBase>();
 
-            return attribute.Procedure;
+            if (!string.IsNullOrEmpty(attribute.Procedure))
+                return attribute.Procedure;
+
+            return member.Name;
         }
     }
 }

--- a/src/net45/WampSharp/WAMP2/V2/Rpc/Callee/Reflection/ICalleeRegistrationInterceptor.cs
+++ b/src/net45/WampSharp/WAMP2/V2/Rpc/Callee/Reflection/ICalleeRegistrationInterceptor.cs
@@ -10,18 +10,19 @@ namespace WampSharp.V2
     public interface ICalleeRegistrationInterceptor
     {
         /// <summary>
-        /// Returns a value indicating whether this method is a callee method.
+        /// Returns a value indicating whether this method is a callee method/member.
         /// </summary>
-        bool IsCalleeProcedure(MethodInfo method);
-
+        bool IsCalleeMember(MemberInfo member);
+        
         /// <summary>
-        /// Gets the options that will be used to register the given method.
+        /// Gets the options that will be used to register given memember
         /// </summary>
-        RegisterOptions GetRegisterOptions(MethodInfo method);
+        RegisterOptions GetRegisterOptions(MemberInfo member);
 
         /// <summary>
         /// Gets the procedure uri that will be used to register the given method.
         /// </summary>
-        string GetProcedureUri(MethodInfo method);
+        string GetProcedureUri(MemberInfo member);
+
     }
 }

--- a/src/net45/WampSharp/WAMP2/V2/Rpc/Callee/Reflection/ICalleeRegistrationInterceptor.cs
+++ b/src/net45/WampSharp/WAMP2/V2/Rpc/Callee/Reflection/ICalleeRegistrationInterceptor.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using WampSharp.V2.Core.Contracts;
 
 // ReSharper disable once CheckNamespace
@@ -9,6 +10,15 @@ namespace WampSharp.V2
     /// </summary>
     public interface ICalleeRegistrationInterceptor
     {
+
+        /// <summary>
+        /// Returns a value indicating whether this method is a callee method. Deprecated. Use <see cref="IsCalleeMember"/>
+        /// </summary>
+#if !PCL
+        [Obsolete("Deprecated.  Use IsCalleeMember for readonly property support")]
+#endif
+        bool IsCalleeProcedure(MethodInfo method);
+        
         /// <summary>
         /// Returns a value indicating whether this method is a callee method/member.
         /// </summary>

--- a/src/net45/WampSharp/WAMP2/V2/Rpc/Callee/Reflection/OperationExtractor.cs
+++ b/src/net45/WampSharp/WAMP2/V2/Rpc/Callee/Reflection/OperationExtractor.cs
@@ -17,10 +17,9 @@ namespace WampSharp.V2.Rpc
 
             foreach (Type currentType in typesToExplore)
             {
-                IEnumerable<OperationToRegister> currentOperations =
-                    GetServiceMethodsOfType(instance, currentType, interceptor);
+                IEnumerable<OperationToRegister> currentMemberOperations = GetServiceMembersOfType(instance, currentType, interceptor);
 
-                foreach (OperationToRegister operation in currentOperations)
+                foreach (OperationToRegister operation in currentMemberOperations)
                 {
                     yield return operation;
                 }
@@ -37,30 +36,51 @@ namespace WampSharp.V2.Rpc
             }
         }
 
-        private IEnumerable<OperationToRegister> GetServiceMethodsOfType
-            (Func<object> instance,
-                Type type,
-                ICalleeRegistrationInterceptor interceptor)
+        private IEnumerable<OperationToRegister> GetServiceMembersOfType
+           (Func<object> instance,
+               Type type,
+               ICalleeRegistrationInterceptor interceptor)
         {
-            foreach (var method in type.GetPublicInstanceMethods())
+            foreach (var member in type.GetPublicInstanceMembers())
             {
-                if (interceptor.IsCalleeProcedure(method))
+                if (interceptor.IsCalleeMember(member))
                 {
-                    IWampRpcOperation operation = CreateRpcMethod(instance, interceptor, method);
-                    RegisterOptions options = interceptor.GetRegisterOptions(method);
+                    IWampRpcOperation operation = CreateRpcMethod(instance, interceptor, member);
+                    RegisterOptions options = interceptor.GetRegisterOptions(member);
 
                     yield return new OperationToRegister(operation, options);
                 }
             }
         }
 
-        private bool HasServiceMethodsInType
+        private IWampRpcOperation CreateRpcMethod(Func<object> instanceProvider, ICalleeRegistrationInterceptor interceptor, MemberInfo member)
+        {
+            if (member.MemberType == MemberTypes.Method)
+            {
+                return CreateRpcMethod(instanceProvider, interceptor, member as MethodInfo);
+            }
+            else if (member.MemberType == MemberTypes.Property)
+            {
+                //Use getter method of a property
+                PropertyInfo propertyInfo = member as PropertyInfo;
+
+                if (propertyInfo.GetMethod != null)
+                    return CreateRpcMethod(instanceProvider, interceptor, propertyInfo.GetMethod, member);
+                else
+                    throw new Exception(string.Format("Getter not found for {1}", member.MemberType, member));
+            }
+
+            throw new Exception(string.Format("Unsupported member type {0} found when registering {1}", member.MemberType, member));
+
+        }
+
+        private bool HasServiceMembersInType
             (Type type,
                 ICalleeRegistrationInterceptor interceptor)
         {
             foreach (var method in type.GetPublicInstanceMethods())
             {
-                if (interceptor.IsCalleeProcedure(method))
+                if (interceptor.IsCalleeMember(method))
                 {
                     return true;
                 }
@@ -69,13 +89,20 @@ namespace WampSharp.V2.Rpc
             return false;
         }
 
-        protected IWampRpcOperation CreateRpcMethod(Func<object> instanceProvider, ICalleeRegistrationInterceptor interceptor, MethodInfo method)
+        //When procedure URI attribute is defined on method itself, not "parent" memember
+        protected IWampRpcOperation CreateRpcMethod(Func<object> instanceProvider,
+            ICalleeRegistrationInterceptor interceptor, MethodInfo method)
+        {
+            return CreateRpcMethod(instanceProvider, interceptor, method, method);
+        }
+
+        protected IWampRpcOperation CreateRpcMethod(Func<object> instanceProvider, ICalleeRegistrationInterceptor interceptor, MethodInfo method, MemberInfo procedureUriSource)
         {
             string procedureUri =
-                interceptor.GetProcedureUri(method);
+                interceptor.GetProcedureUri(procedureUriSource);
 
             //TODO: need better detection of nested
-            if (HasServiceMethodsInType(method.ReturnType, interceptor) && method.GetParameters().Length == 0)
+            if (HasServiceMembersInType(method.ReturnType, interceptor) && method.GetParameters().Length == 0)
             {
                 return new LocalRpcInterfaceOperation(method.ReturnType, () => method.Invoke(instanceProvider(), new object[]{}), procedureUri, interceptor);
             }

--- a/src/net45/WampSharp/WAMP2/V2/Rpc/Callee/Reflection/OperationExtractor.cs
+++ b/src/net45/WampSharp/WAMP2/V2/Rpc/Callee/Reflection/OperationExtractor.cs
@@ -64,8 +64,8 @@ namespace WampSharp.V2.Rpc
                 //Use getter method of a property
                 PropertyInfo propertyInfo = member as PropertyInfo;
 
-                if (propertyInfo.GetMethod != null)
-                    return CreateRpcMethod(instanceProvider, interceptor, propertyInfo.GetMethod, member);
+                if (propertyInfo.GetGetMethod() != null)
+                    return CreateRpcMethod(instanceProvider, interceptor, propertyInfo.GetGetMethod(), member);
                 else
                     throw new Exception(string.Format("Getter not found for {1}", member.MemberType, member));
             }

--- a/src/net45/WampSharp/WAMP2/V2/Rpc/Callee/Reflection/OperationExtractor.cs
+++ b/src/net45/WampSharp/WAMP2/V2/Rpc/Callee/Reflection/OperationExtractor.cs
@@ -73,9 +73,8 @@ namespace WampSharp.V2.Rpc
             }
             throw new Exception(string.Format("Unsupported member type {0} found when registering {1}", member.MemberType, member));
 #else
-
-#endif
             return CreateRpcMethod(instanceProvider, interceptor, member as MethodInfo);
+#endif
         }
 
         private bool HasServiceMembersInType

--- a/src/net45/WampSharp/WAMP2/V2/Rpc/Callee/Reflection/OperationExtractor.cs
+++ b/src/net45/WampSharp/WAMP2/V2/Rpc/Callee/Reflection/OperationExtractor.cs
@@ -55,6 +55,8 @@ namespace WampSharp.V2.Rpc
 
         private IWampRpcOperation CreateRpcMethod(Func<object> instanceProvider, ICalleeRegistrationInterceptor interceptor, MemberInfo member)
         {
+
+#if !PCL
             if (member.MemberType == MemberTypes.Method)
             {
                 return CreateRpcMethod(instanceProvider, interceptor, member as MethodInfo);
@@ -69,9 +71,11 @@ namespace WampSharp.V2.Rpc
                 else
                     throw new Exception(string.Format("Getter not found for {1}", member.MemberType, member));
             }
-
             throw new Exception(string.Format("Unsupported member type {0} found when registering {1}", member.MemberType, member));
+#else
 
+#endif
+            return CreateRpcMethod(instanceProvider, interceptor, member as MethodInfo);
         }
 
         private bool HasServiceMembersInType

--- a/src/net45/WampSharp/WAMP2/V2/Rpc/WampProcedureAttribute.cs
+++ b/src/net45/WampSharp/WAMP2/V2/Rpc/WampProcedureAttribute.cs
@@ -2,22 +2,18 @@
 
 namespace WampSharp.V2.Rpc
 {
-    /// <summary>
-    /// Indicates this method respresents a WAMPv2 rpc procedure.
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Method, Inherited = true, AllowMultiple = false)]
-    public sealed class WampProcedureAttribute : Attribute
+    public class WampMemberAttributeBase : Attribute
     {
-        private readonly string mProcedure;
+        private string mMemberName;
 
         /// <summary>
         /// Initializes a new instance of <see cref="WampProcedureAttribute"/> given
         /// the procedure uri this method is mapped to.
         /// </summary>
         /// <param name="procedure">The given the procedure uri this method is mapped to.</param>
-        public WampProcedureAttribute(string procedure)
+        public WampMemberAttributeBase(string procedure)
         {
-            this.mProcedure = procedure;
+            this.mMemberName = procedure;
         }
 
         /// <summary>
@@ -27,8 +23,49 @@ namespace WampSharp.V2.Rpc
         {
             get
             {
-                return mProcedure;
+                return mMemberName;
             }
+        }
+    }
+
+    /// <summary>
+    /// Indicates this method respresents a WAMPv2 rpc procedure.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, Inherited = true, AllowMultiple = false)]
+    public sealed class WampProcedureAttribute : WampMemberAttributeBase
+    {
+        /// <summary>
+        /// Initializes a new instance of <see cref="WampProcedureAttribute"/> given
+        /// the procedure uri this method is mapped to.
+        /// </summary>
+        /// <param name="procedure">The given the procedure uri this method is mapped to.</param>
+        public WampProcedureAttribute(string procedure) : base(procedure)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Indicates this method respresents a WAMPv2 rpc member (that has rpc members/procedures).
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = true, AllowMultiple = false)]
+    public sealed class WampMemberAttribute : WampMemberAttributeBase
+    {
+        /// <summary>
+        /// Initializes a new instance of <see cref="WampProcedureAttribute"/> given
+        /// the procedure uri this method is mapped to.
+        /// </summary>
+        /// <param name="procedure">The given the procedure uri this method is mapped to.</param>
+        public WampMemberAttribute(string procedure) : base(procedure)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="WampProcedureAttribute"/> given
+        /// the procedure uri this method is mapped to.
+        /// </summary>
+        /// <param name="procedure">The given the procedure uri this method is mapped to.</param>
+        public WampMemberAttribute() : base(String.Empty)
+        {
         }
     }
 }

--- a/src/net45/WampSharp/WampSharp.csproj
+++ b/src/net45/WampSharp/WampSharp.csproj
@@ -309,6 +309,7 @@
     <Compile Include="WAMP2\V2\Realm\WampRouterBuilder.cs" />
     <Compile Include="WAMP2\V2\PubSub\TopicContainerExtensions.cs" />
     <Compile Include="WAMP2\V2\MetaApi\PubSub\SubscriptionDetailsExtended.cs" />
+    <Compile Include="WAMP2\V2\Rpc\Callee\LocalRpcInterfaceOperation.cs" />
     <Compile Include="WAMP2\V2\Rpc\Callee\Reflection\CalleeRegistrationInterceptor.cs" />
     <Compile Include="WAMP2\V2\Api\CalleeProxy\ProgressiveAsyncCalleeProxyInterceptor.cs" />
     <Compile Include="WAMP2\V2\Api\CalleeProxy\ICalleeProxyInterceptor.cs" />

--- a/src/pcl/WampSharp/WampSharp.csproj
+++ b/src/pcl/WampSharp/WampSharp.csproj
@@ -782,6 +782,9 @@
     <Compile Include="..\..\net45\WampSharp\WAMP2\V2\MetaApi\PubSub\SubscriptionDetailsExtended.cs">
       <Link>WAMP2\V2\MetaApi\PubSub\SubscriptionDetailsExtended.cs</Link>
     </Compile>
+    <Compile Include="..\..\net45\WampSharp\WAMP2\V2\Rpc\Callee\LocalRpcInterfaceOperation.cs">
+      <Link>WAMP2\V2\Rpc\Callee\LocalRpcInterfaceOperation.cs</Link>
+    </Compile>
     <Compile Include="..\..\net45\WampSharp\WAMP2\V2\Rpc\Callee\Reflection\CalleeRegistrationInterceptor.cs">
       <Link>WAMP2\V2\Rpc\Callee\Reflection\CalleeRegistrationInterceptor.cs</Link>
     </Compile>


### PR DESCRIPTION
Register procedure prefix and provide a collection of nested services without having to register every single procedure
```
var operation = new LocalRpcInterfaceOperation(instance, "com.test.instance.124");


Task<IAsyncDisposable> registrationTask =
                calleeChannel.RealmProxy.RpcCatalog.Register(operation,
                                                   new RegisterOptions()
                                                   {
                                                       Match = WampMatchPattern.Prefix
                                                   });
```
Where `instance` is an object implementing 

```
public interface IRpcCompositeService
    {
        [WampProcedure("test")]
        IRpcTestSubService GetTestSubService();

        [WampProcedure("switchAppliance")]
        void SwitchAppliance();

        [WampMember]
        IApplianceSubService appliance { get; }

        [WampProcedure("version")]
        string version();
    }
```
It's property `appliance` implements interface.  Can be called with "com.test.instance.124.appliance.brew"

```
    public interface IApplianceSubService
    {
        [WampMember]
        int capacity { get; }

        [WampProcedure("brew")]
        Task<string> brew(int amount);
    }
```