### PR TITLE
More details (stacktrace) for the caller

### DIFF
--- a/src/net45/Extensions/WampSharp.WebSockets/WebSocket/WebSocketConnection.cs
+++ b/src/net45/Extensions/WampSharp.WebSockets/WebSocket/WebSocketConnection.cs
@@ -102,7 +102,7 @@ namespace WampSharp.WebSockets
                         length += webSocketReceiveResult.Count;
 
                         await memoryStream.WriteAsync(receivedDataBuffer.Array, receivedDataBuffer.Offset,
-                                                      receivedDataBuffer.Count, mCancellationTokenSource.Token)
+                                                      webSocketReceiveResult.Count, mCancellationTokenSource.Token)
                                           .ConfigureAwait(false);
 
                     } while (!webSocketReceiveResult.EndOfMessage);

--- a/src/net45/global.json
+++ b/src/net45/global.json
@@ -1,6 +1,6 @@
 {
   "projects": [ ".", "Default", "Extensions", "Tests" ],
   "sdk": {
-    "version": "1.0.0-preview2-003121"
+    "version": "1.0.0-preview2-003131"
   }
 }


### PR DESCRIPTION
When the caller was getting an exception back from the callee, it was confusing where the exception was being throw. Adding the stack trace to the details of the reject message would be helpful for tracing the source of the error.
