### PR TITLE
Add Xamarin.iOS10 Support

### DIFF
--- a/NuGet/WampSharp.nuspec
+++ b/NuGet/WampSharp.nuspec
@@ -58,6 +58,12 @@
         <dependency id="System.Text.RegularExpressions" version="[4.1.0, )" />
         <dependency id="System.ValueTuple" version="[4.0.0-rc3-24212-01, )" />
       </group>
+      <group targetFramework="Xamarin.iOS10">
+        <dependency id="System.Reactive" version="[3.0.0, )" />
+        <dependency id="System.Collections.Immutable" version="[1.2.0, )" />
+        <dependency id="System.Threading.Tasks.Dataflow" version="[4.6.0, )" />
+        <dependency id="System.ValueTuple" version="[4.0.0-rc3-24212-01, )" />
+      </group>
     </dependencies>
     <id>WampSharp</id>
     <title>WampSharp</title>
@@ -73,6 +79,8 @@
     <file src="bin\net40\WampSharp.xml" target="lib\net40\WampSharp.xml" />
     <file src="bin\pcl\WampSharp.dll" target="lib\portable-win81+wpa81\WampSharp.dll" />
     <file src="bin\pcl\WampSharp.xml" target="lib\portable-win81+wpa81\WampSharp.xml" />
+    <file src="bin\pcl\WampSharp.dll" target="lib\Xamarin.iOS10\WampSharp.dll" />
+    <file src="bin\pcl\WampSharp.xml" target="lib\Xamarin.iOS10\WampSharp.xml" />
     <file src="bin\netstandard1.3\WampSharp.dll" target="lib\netstandard1.3\WampSharp.dll" />
     <file src="bin\netstandard1.3\WampSharp.xml" target="lib\netstandard1.3\WampSharp.xml" />
     <file src="bin\uap10.0\WampSharp.dll" target="lib\uap10.0\WampSharp.dll" />


### PR DESCRIPTION
Xamarin.iOS10 [does not support System.Reflection.Emit ](https://developer.xamarin.com/guides/ios/advanced_topics/limitations/)(despite advertising support for NetStandard 1.3).  To work around this issue we added a build targeted for ".NETPortable,Version=v4.5,Profile=Profile7" which accounts for Xamarin.iOS10 limitations.  We associated this new build with Xamarin.iOS10 via additional .nuspec entries.

This pull request will require updating the build process to place the two distinct PCL builds ("UAP10.0" and ".NETPortable,Version=v4.5,Profile=Profile7") into distinct folders ("bin\portable-win81+wpa81\" and "bin\portable-net45+netcore45" respectively) to avoid a collision in the existing "bin\pcl\" folder.