### PR TITLE
Fixed performance issue when sending data

### DIFF
--- a/src/net45/Extensions/WampSharp.WebSockets/WebSockets/WebSocketWrapperConnection.cs
+++ b/src/net45/Extensions/WampSharp.WebSockets/WebSockets/WebSocketWrapperConnection.cs
@@ -39,7 +39,6 @@ namespace WampSharp.WebSockets
 
         protected override Task SendAsync(WampMessage<object> message)
         {
-            mLogger.Debug("Attempting to send a message");
             ArraySegment<byte> messageToSend = GetMessageInBytes(message);
             return mWebSocket.SendAsync(messageToSend, WebSocketMessageType, true, mCancellationToken);
         }


### PR DESCRIPTION
When using topics for high frequency requests CPU usage is extremely high.
After profiling found that problem is in attempt to write debug logs.
Details:
mLogger.Debug using several wrappers calls LoggerWithConnectionId.Log
On every attempt to add debug log, it tries to create context, wich do the following:
ILogProvider logProvider = CurrentLogProvider ?? ResolveLogProvider();
CurrentLogProvider is always null, so we always call ResolveLogProvider, wich tries to call IsLoggerAvailable for every handled logger, wich do for example in case of NLog Type.GetType("NLog.LogManager, NLog");
So... On every send data, it tries to get 5 types, while trying to write useless log message.
I suggest deleting this useless log record, as it is the simpliest way to fix performance.
If this log is necessary for some reason, then LoggerWithConnectionId.Log method should be fixed and if no logging enabled return false immediately.
P. S. The problem appeared in commit https://github.com/Code-Sharp/WampSharp/commit/2bee21bbd5f6441f33a73cdd3a0a08469adaf685