### PR TITLE
Add dual stack support

### DIFF
--- a/src/net40/Default/WampSharp.Fleck/WampSharp.Fleck.csproj
+++ b/src/net40/Default/WampSharp.Fleck/WampSharp.Fleck.csproj
@@ -35,7 +35,7 @@
     <ProjectReference Include="..\..\WampSharp\WampSharp.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Fleck" Version="0.14.0.59" />
+    <PackageReference Include="Fleck" Version="1.1.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/net40/WampSharpFw4.sln
+++ b/src/net40/WampSharpFw4.sln
@@ -2,8 +2,6 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.27130.2024
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WampSharp", "WampSharp\WampSharp.csproj", "{653A76DC-00D7-4EFF-A25E-2FA10C5C927D}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Samples", "Samples", "{33E2A6E5-246F-420B-A13C-AA4B617EBFB2}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "WAMP1", "WAMP1", "{10B51C05-30BC-412A-BFFB-8C2C02753528}"
@@ -60,6 +58,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WampSharp.Samples.WampCra.C
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WampSharp.Samples.WampCra.Router", "Samples\WAMP2\WampSharp.Samples.WampCra.Router\WampSharp.Samples.WampCra.Router.csproj", "{A4661436-103A-49F9-9D63-91DF66FB145B}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WampSharp", "WampSharp\WampSharp.csproj", "{3BB0FD7F-2939-4893-9746-45BFB9B5CB44}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -72,16 +72,6 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{653A76DC-00D7-4EFF-A25E-2FA10C5C927D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{653A76DC-00D7-4EFF-A25E-2FA10C5C927D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{653A76DC-00D7-4EFF-A25E-2FA10C5C927D}.Debug|ARM.ActiveCfg = Debug|Any CPU
-		{653A76DC-00D7-4EFF-A25E-2FA10C5C927D}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{653A76DC-00D7-4EFF-A25E-2FA10C5C927D}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{653A76DC-00D7-4EFF-A25E-2FA10C5C927D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{653A76DC-00D7-4EFF-A25E-2FA10C5C927D}.Release|Any CPU.Build.0 = Release|Any CPU
-		{653A76DC-00D7-4EFF-A25E-2FA10C5C927D}.Release|ARM.ActiveCfg = Release|Any CPU
-		{653A76DC-00D7-4EFF-A25E-2FA10C5C927D}.Release|x64.ActiveCfg = Release|Any CPU
-		{653A76DC-00D7-4EFF-A25E-2FA10C5C927D}.Release|x86.ActiveCfg = Release|Any CPU
 		{AD5C9AA6-6810-488E-9EDD-FCC945AAD627}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{AD5C9AA6-6810-488E-9EDD-FCC945AAD627}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AD5C9AA6-6810-488E-9EDD-FCC945AAD627}.Debug|ARM.ActiveCfg = Debug|Any CPU
@@ -324,6 +314,22 @@ Global
 		{A4661436-103A-49F9-9D63-91DF66FB145B}.Release|x64.Build.0 = Release|Any CPU
 		{A4661436-103A-49F9-9D63-91DF66FB145B}.Release|x86.ActiveCfg = Release|Any CPU
 		{A4661436-103A-49F9-9D63-91DF66FB145B}.Release|x86.Build.0 = Release|Any CPU
+		{3BB0FD7F-2939-4893-9746-45BFB9B5CB44}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3BB0FD7F-2939-4893-9746-45BFB9B5CB44}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3BB0FD7F-2939-4893-9746-45BFB9B5CB44}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{3BB0FD7F-2939-4893-9746-45BFB9B5CB44}.Debug|ARM.Build.0 = Debug|Any CPU
+		{3BB0FD7F-2939-4893-9746-45BFB9B5CB44}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3BB0FD7F-2939-4893-9746-45BFB9B5CB44}.Debug|x64.Build.0 = Debug|Any CPU
+		{3BB0FD7F-2939-4893-9746-45BFB9B5CB44}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3BB0FD7F-2939-4893-9746-45BFB9B5CB44}.Debug|x86.Build.0 = Debug|Any CPU
+		{3BB0FD7F-2939-4893-9746-45BFB9B5CB44}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3BB0FD7F-2939-4893-9746-45BFB9B5CB44}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3BB0FD7F-2939-4893-9746-45BFB9B5CB44}.Release|ARM.ActiveCfg = Release|Any CPU
+		{3BB0FD7F-2939-4893-9746-45BFB9B5CB44}.Release|ARM.Build.0 = Release|Any CPU
+		{3BB0FD7F-2939-4893-9746-45BFB9B5CB44}.Release|x64.ActiveCfg = Release|Any CPU
+		{3BB0FD7F-2939-4893-9746-45BFB9B5CB44}.Release|x64.Build.0 = Release|Any CPU
+		{3BB0FD7F-2939-4893-9746-45BFB9B5CB44}.Release|x86.ActiveCfg = Release|Any CPU
+		{3BB0FD7F-2939-4893-9746-45BFB9B5CB44}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/net45/Default/WampSharp.Fleck/Fleck/FleckAuthenticatedWebSocketTransport.cs
+++ b/src/net45/Default/WampSharp.Fleck/Fleck/FleckAuthenticatedWebSocketTransport.cs
@@ -10,8 +10,9 @@ namespace WampSharp.Fleck
         public FleckAuthenticatedWebSocketTransport
             (string location,
              ICookieAuthenticatorFactory cookieAuthenticatorFactory = null,
-             X509Certificate2 certificate = null)
-            : this(location: location, cookieAuthenticatorFactory: cookieAuthenticatorFactory, certificate: certificate, getEnabledSslProtocols: null)
+             X509Certificate2 certificate = null,
+             bool supportDualStack = true)
+            : this(location: location, supportDualStack: supportDualStack, cookieAuthenticatorFactory: cookieAuthenticatorFactory, certificate: certificate, getEnabledSslProtocols: null)
         {
         }
 
@@ -19,8 +20,9 @@ namespace WampSharp.Fleck
             (string location,
              ICookieAuthenticatorFactory cookieAuthenticatorFactory = null,
              X509Certificate2 certificate = null,
-             Func<SslProtocols> getEnabledSslProtocols = null)
-            : base(location, cookieAuthenticatorFactory, certificate, getEnabledSslProtocols)
+             Func<SslProtocols> getEnabledSslProtocols = null,
+             bool supportDualStack = true)
+            : base(location, cookieAuthenticatorFactory, certificate, getEnabledSslProtocols, supportDualStack)
         {
         }
     }

--- a/src/net45/Default/WampSharp.Fleck/Fleck/FleckWebSocketTransport.cs
+++ b/src/net45/Default/WampSharp.Fleck/Fleck/FleckWebSocketTransport.cs
@@ -23,9 +23,10 @@ namespace WampSharp.Fleck
         /// given the server address to run at.
         /// </summary>
         /// <param name="location">The given server address.</param>
+        /// <param name="supportDualStack">IPv4/IPv6 dual stack support</param>
         /// <param name="certificate">The <see cref="X509Certificate2"/> certificate to use for secured websockets.</param>
-        public FleckWebSocketTransport(string location, X509Certificate2 certificate = null)
-            : this(location: location, cookieAuthenticatorFactory: null, certificate: certificate, getEnabledSslProtocols: null)
+        public FleckWebSocketTransport(string location, bool supportDualStack = true, X509Certificate2 certificate = null)
+            : this(location: location, supportDualStack: supportDualStack, cookieAuthenticatorFactory: null, certificate: certificate, getEnabledSslProtocols: null)
         {
         }
 
@@ -34,10 +35,11 @@ namespace WampSharp.Fleck
         /// given the server address to run at.
         /// </summary>
         /// <param name="location">The given server address.</param>
+        /// <param name="supportDualStack">IPv4/IPv6 dual stack support</param>
         /// <param name="certificate">The <see cref="X509Certificate2"/> certificate to use for secured websockets.</param>
         /// <param name="getEnabledSslProtocols"> If non-null, used to set Fleck's EnabledSslProtocols. </param>
-        public FleckWebSocketTransport(string location, X509Certificate2 certificate, Func<SslProtocols> getEnabledSslProtocols)
-            : this(location: location, cookieAuthenticatorFactory: null, certificate: certificate, getEnabledSslProtocols: getEnabledSslProtocols)
+        public FleckWebSocketTransport(string location, X509Certificate2 certificate, Func<SslProtocols> getEnabledSslProtocols, bool supportDualStack = true)
+            : this(location: location, supportDualStack: supportDualStack, cookieAuthenticatorFactory: null, certificate: certificate, getEnabledSslProtocols: getEnabledSslProtocols)
         {
         }
 
@@ -48,10 +50,12 @@ namespace WampSharp.Fleck
         /// <param name="location">The given server address.</param>
         /// <param name="cookieAuthenticatorFactory"></param>
         /// <param name="certificate">The <see cref="X509Certificate2"/> certificate to use for secured websockets.</param>
+        /// <param name="supportDualStack">IPv4/IPv6 dual stack support</param>
         protected FleckWebSocketTransport(string location,
                                           ICookieAuthenticatorFactory cookieAuthenticatorFactory = null,
-                                          X509Certificate2 certificate = null)
-            : this(location: location, cookieAuthenticatorFactory: null, certificate: certificate, getEnabledSslProtocols: null)
+                                          X509Certificate2 certificate = null,
+                                          bool supportDualStack = true)
+            : this(location: location, cookieAuthenticatorFactory: null, certificate: certificate, supportDualStack: supportDualStack, getEnabledSslProtocols: null)
         {
         }
 
@@ -62,14 +66,16 @@ namespace WampSharp.Fleck
         /// <param name="location">The given server address.</param>
         /// <param name="cookieAuthenticatorFactory"></param>
         /// <param name="certificate">The <see cref="X509Certificate2"/> certificate to use for secured websockets.</param>
+        /// <param name="supportDualStack">IPv4/IPv6 dual stack support</param>
         /// <param name="getEnabledSslProtocols"> If non-null, used to set Fleck's EnabledSslProtocols. </param>
         protected FleckWebSocketTransport(string location,
                                           ICookieAuthenticatorFactory cookieAuthenticatorFactory = null,
                                           X509Certificate2 certificate = null,
-                                          Func<SslProtocols> getEnabledSslProtocols = null)
+                                          Func<SslProtocols> getEnabledSslProtocols = null,
+                                          bool supportDualStack = true)
             : base(cookieAuthenticatorFactory)
         {
-            mServer = new WebSocketServer(location);
+            mServer = new WebSocketServer(location, supportDualStack);
             mServer.Certificate = certificate;
 
             if (getEnabledSslProtocols != null)

--- a/src/net45/Default/WampSharp.Fleck/WampSharp.Fleck.csproj
+++ b/src/net45/Default/WampSharp.Fleck/WampSharp.Fleck.csproj
@@ -43,7 +43,7 @@
     <ProjectReference Include="..\..\WampSharp\WampSharp.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Fleck" Version="1.0.3" />
+    <PackageReference Include="Fleck" Version="1.1.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/net46/Default/WampSharp.Fleck/WampSharp.Fleck.csproj
+++ b/src/net46/Default/WampSharp.Fleck/WampSharp.Fleck.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\WampSharp\WampSharp.csproj" />
-    <PackageReference Include="Fleck" Version="1.0.3" />
+    <PackageReference Include="Fleck" Version="1.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/netstandard2.0/Default/WampSharp.Fleck/WampSharp.Fleck.csproj
+++ b/src/netstandard2.0/Default/WampSharp.Fleck/WampSharp.Fleck.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\WampSharp\WampSharp.csproj" />
-    <PackageReference Include="Fleck" Version="1.0.3" />
+    <PackageReference Include="Fleck" Version="1.1.0" />
   </ItemGroup>
 
 


### PR DESCRIPTION
# Goal

Add the possibility to support (or not) the IPv4/IPv6 dual stack for the sockets. Actually this wasn't working on old system like Windows XP because it wasn't supporting the dual stack.

# What was done

The first step was to update the `Fleck` library to the `v1.1.0` that was released recently. This permit to give to the Fleck object constructor a boolean who specify if we support or not the dual stack.
Next we add the property to the `FleckAuthenticatedWebSocketTransport` and `FleckWebSocketTransport` constructors.

# How to use it.

When we create the host we can call the method `host.RegisterTransport` where we can set a custom `FleckAuthenticatedWebSocketTransport` object with the support dual stack boolean that we want.