### PR TITLE
Add support dual stack in host

### DIFF
--- a/src/net45/WampSharp.Default.Router/WAMP2/V2/DefaultWampAuthenticationHost.cs
+++ b/src/net45/WampSharp.Default.Router/WAMP2/V2/DefaultWampAuthenticationHost.cs
@@ -27,11 +27,14 @@ namespace WampSharp.V2
         /// <param name="location">The given location.</param>
         /// <param name="sessionAuthenticationFactory">The <see cref="IWampSessionAuthenticatorFactory"/>
         /// used to accept pending clients.</param>
+        /// <param name="supportDualStack">IPv4/IPv6 dual stack support</param>
         public DefaultWampAuthenticationHost
             (string location,
-             IWampSessionAuthenticatorFactory sessionAuthenticationFactory)
+             IWampSessionAuthenticatorFactory sessionAuthenticationFactory,
+             bool supportDualStack = true)
             : this(location: location,
                    sessionAuthenticationFactory: sessionAuthenticationFactory,
+                   supportDualStack: supportDualStack,
                    cookieAuthenticatorFactory: null,
                    certificate: null)
         {
@@ -48,16 +51,19 @@ namespace WampSharp.V2
         /// <param name="cookieAuthenticatorFactory">The given <see cref="ICookieAuthenticatorFactory"/> used to authenticate
         /// users given their cookies.</param>
         /// <param name="certificate">The <see cref="X509Certificate2"/> certificate to use for secured websockets.</param>
+        /// <param name="supportDualStack">IPv4/IPv6 dual stack support</param>
         public DefaultWampAuthenticationHost
             (string location,
              IWampSessionAuthenticatorFactory sessionAuthenticationFactory,
              ICookieAuthenticatorFactory cookieAuthenticatorFactory = null,
-             X509Certificate2 certificate = null)
+             X509Certificate2 certificate = null,
+             bool supportDualStack = true)
             : this(location: location,
                    sessionAuthenticationFactory: sessionAuthenticationFactory,
                    bindings: null,
                    cookieAuthenticatorFactory: cookieAuthenticatorFactory,
-                   certificate: certificate)
+                   certificate: certificate,
+                   supportDualStack: supportDualStack)
         {
         }
 
@@ -71,18 +77,22 @@ namespace WampSharp.V2
         /// <param name="bindings">The given bindings.</param>
         /// <param name="cookieAuthenticatorFactory"></param>
         /// <param name="certificate">The <see cref="X509Certificate2"/> certificate to use for secured websockets.</param>
+        /// <param name="supportDualStack">IPv4/IPv6 dual stack support</param>
         public DefaultWampAuthenticationHost
             (string location,
              IWampSessionAuthenticatorFactory sessionAuthenticationFactory,
              IEnumerable<IWampBinding> bindings = null,
              ICookieAuthenticatorFactory cookieAuthenticatorFactory = null,
-             X509Certificate2 certificate = null)
+             X509Certificate2 certificate = null,
+             bool supportDualStack = true)
             : this(location: location,
                    sessionAuthenticationFactory: sessionAuthenticationFactory,
                    realmContainer: null,
                    uriValidator: null,
                    bindings: bindings,
-                   cookieAuthenticatorFactory: cookieAuthenticatorFactory, certificate: certificate)
+                   cookieAuthenticatorFactory: cookieAuthenticatorFactory,
+                   certificate: certificate,
+                   supportDualStack: supportDualStack)
         {
         }
 
@@ -101,13 +111,15 @@ namespace WampSharp.V2
         /// <param name="cookieAuthenticatorFactory">The given <see cref="ICookieAuthenticatorFactory"/> used to authenticate
         /// users given their cookies.</param>
         /// <param name="certificate">The <see cref="X509Certificate2"/> certificate to use for secured websockets.</param>
+        /// <param name="supportDualStack">IPv4/IPv6 dual stack support</param>
         public DefaultWampAuthenticationHost(string location,
             IWampSessionAuthenticatorFactory sessionAuthenticationFactory,
             IWampRealmContainer realmContainer = null,
             IWampUriValidator uriValidator = null,
             IEnumerable<IWampBinding> bindings = null,
             ICookieAuthenticatorFactory cookieAuthenticatorFactory = null,
-            X509Certificate2 certificate = null)
+            X509Certificate2 certificate = null,
+            bool supportDualStack = true)
             : this(location: location,
                    sessionAuthenticationFactory: sessionAuthenticationFactory,
                    realmContainer: null,
@@ -115,7 +127,8 @@ namespace WampSharp.V2
                    bindings: bindings,
                    cookieAuthenticatorFactory: cookieAuthenticatorFactory, 
                    certificate: certificate,
-                   getEnabledSslProtocols: null)
+                   getEnabledSslProtocols: null,
+                   supportDualStack: supportDualStack)
         {
         }
 
@@ -134,6 +147,7 @@ namespace WampSharp.V2
         /// <param name="cookieAuthenticatorFactory">The given <see cref="ICookieAuthenticatorFactory"/> used to authenticate
         /// users given their cookies.</param>
         /// <param name="certificate">The <see cref="X509Certificate2"/> certificate to use for secured websockets.</param>
+        /// <param name="supportDualStack">IPv4/IPv6 dual stack support</param>
         /// <param name="getEnabledSslProtocols"> If non-null, used to set Fleck's EnabledSslProtocols. </param>
         public DefaultWampAuthenticationHost(string location,
                                              IWampSessionAuthenticatorFactory sessionAuthenticationFactory,
@@ -142,13 +156,14 @@ namespace WampSharp.V2
                                              IEnumerable<IWampBinding> bindings = null,
                                              ICookieAuthenticatorFactory cookieAuthenticatorFactory = null,
                                              X509Certificate2 certificate = null,
+                                             bool supportDualStack = true,
                                              Func<SslProtocols> getEnabledSslProtocols = null)
             : base(sessionAuthenticationFactory, realmContainer, uriValidator)
         {
             bindings = bindings ?? new IWampBinding[] { new JTokenJsonBinding(), new JTokenMsgpackBinding() };
 
             this.RegisterTransport(
-                new FleckAuthenticatedWebSocketTransport(location, cookieAuthenticatorFactory, certificate, getEnabledSslProtocols),
+                new FleckAuthenticatedWebSocketTransport(location, cookieAuthenticatorFactory, certificate, getEnabledSslProtocols, supportDualStack),
                 bindings.ToArray());
         }
 

--- a/src/net45/WampSharp.Default.Router/WAMP2/V2/DefaultWampAuthenticationHost.cs
+++ b/src/net45/WampSharp.Default.Router/WAMP2/V2/DefaultWampAuthenticationHost.cs
@@ -29,6 +29,26 @@ namespace WampSharp.V2
         /// used to accept pending clients.</param>
         /// <param name="supportDualStack">IPv4/IPv6 dual stack support</param>
         public DefaultWampAuthenticationHost
+        (string location,
+            IWampSessionAuthenticatorFactory sessionAuthenticationFactory)
+            : this(location: location,
+                sessionAuthenticationFactory: sessionAuthenticationFactory,
+                supportDualStack: true,
+                cookieAuthenticatorFactory: null,
+                certificate: null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="DefaultWampAuthenticationHost"/> listening at
+        /// the given location with the given bindings and the given
+        /// <see cref="IWampRealmContainer"/>.
+        /// </summary>
+        /// <param name="location">The given location.</param>
+        /// <param name="sessionAuthenticationFactory">The <see cref="IWampSessionAuthenticatorFactory"/>
+        /// used to accept pending clients.</param>
+        /// <param name="supportDualStack">IPv4/IPv6 dual stack support</param>
+        public DefaultWampAuthenticationHost
             (string location,
              IWampSessionAuthenticatorFactory sessionAuthenticationFactory,
              bool supportDualStack = true)

--- a/src/net45/WampSharp.Default.Router/WAMP2/V2/DefaultWampHost.cs
+++ b/src/net45/WampSharp.Default.Router/WAMP2/V2/DefaultWampHost.cs
@@ -24,8 +24,9 @@ namespace WampSharp.V2
         /// <see cref="IWampRealmContainer"/>.
         /// </summary>
         /// <param name="location">The given location.</param>
-        public DefaultWampHost(string location)
-            : this(location: location, certificate: null)
+        /// <param name="supportDualStack">IPv4/IPv6 dual stack support</param>
+        public DefaultWampHost(string location, bool supportDualStack = true)
+            : this(location: location, certificate: null, supportDualStack: supportDualStack)
         {
         }
 
@@ -36,8 +37,9 @@ namespace WampSharp.V2
         /// </summary>
         /// <param name="location">The given location.</param>
         /// <param name="certificate">The <see cref="X509Certificate2"/> certificate to use for secured websockets.</param>
-        public DefaultWampHost(string location, X509Certificate2 certificate = null)
-            : this(location: location, bindings: null, certificate: certificate)
+        /// <param name="supportDualStack">IPv4/IPv6 dual stack support</param>
+        public DefaultWampHost(string location, X509Certificate2 certificate = null, bool supportDualStack = true)
+            : this(location: location, bindings: null, certificate: certificate, supportDualStack: supportDualStack)
         {
         }
 
@@ -49,8 +51,9 @@ namespace WampSharp.V2
         /// <param name="location">The given location.</param>
         /// <param name="bindings">The given bindings.</param>
         /// <param name="certificate">The <see cref="X509Certificate2"/> certificate to use for secured websockets.</param>
-        public DefaultWampHost(string location, IEnumerable<IWampBinding> bindings, X509Certificate2 certificate = null)
-            : this(location: location, realmContainer: null, uriValidator: null, bindings: bindings, certificate: certificate)
+        /// <param name="supportDualStack">IPv4/IPv6 dual stack support</param>
+        public DefaultWampHost(string location, IEnumerable<IWampBinding> bindings, X509Certificate2 certificate = null, bool supportDualStack = true)
+            : this(location: location, realmContainer: null, uriValidator: null, bindings: bindings, certificate: certificate, supportDualStack: supportDualStack)
         {
         }
 
@@ -64,12 +67,15 @@ namespace WampSharp.V2
         /// <param name="uriValidator">The <see cref="IWampUriValidator"/> to use to validate uris.</param>
         /// <param name="bindings">The given bindings.</param>
         /// <param name="certificate">The <see cref="X509Certificate2"/> certificate to use for secured websockets.</param>
+        /// <param name="supportDualStack">IPv4/IPv6 dual stack support</param>
         public DefaultWampHost(string location,
             IWampRealmContainer realmContainer = null,
             IWampUriValidator uriValidator = null,
             IEnumerable<IWampBinding> bindings = null,
-            X509Certificate2 certificate = null)
-            : this(location: location, realmContainer: null, uriValidator: null, bindings: bindings, certificate: certificate, getEnabledSslProtocols: null)
+            X509Certificate2 certificate = null,
+            bool supportDualStack = true)
+            : this(location: location, realmContainer: null, uriValidator: null, bindings: bindings, 
+                   certificate: certificate, supportDualStack: supportDualStack, getEnabledSslProtocols: null)
         {
         }
 
@@ -83,18 +89,20 @@ namespace WampSharp.V2
         /// <param name="uriValidator">The <see cref="IWampUriValidator"/> to use to validate uris.</param>
         /// <param name="bindings">The given bindings.</param>
         /// <param name="certificate">The <see cref="X509Certificate2"/> certificate to use for secured websockets.</param>
+        /// <param name="supportDualStack">IPv4/IPv6 dual stack support</param>
         /// <param name="getEnabledSslProtocols"> If non-null, used to set Fleck's EnabledSslProtocols. </param>
         public DefaultWampHost(string location,
             IWampRealmContainer realmContainer = null,
             IWampUriValidator uriValidator = null,
             IEnumerable<IWampBinding> bindings = null,
             X509Certificate2 certificate = null,
+            bool supportDualStack = true,
             Func<SslProtocols> getEnabledSslProtocols = null)
             : base(realmContainer, uriValidator)
         {
             bindings = bindings ?? new IWampBinding[] {new JTokenJsonBinding(), new JTokenMsgpackBinding()};
 
-            this.RegisterTransport(new FleckWebSocketTransport(location, certificate, getEnabledSslProtocols),
+            this.RegisterTransport(new FleckWebSocketTransport(location, certificate, getEnabledSslProtocols, supportDualStack),
                                    bindings.ToArray());
         }
 

--- a/src/net45/WampSharp.Default.Router/WAMP2/V2/DefaultWampHost.cs
+++ b/src/net45/WampSharp.Default.Router/WAMP2/V2/DefaultWampHost.cs
@@ -18,6 +18,18 @@ namespace WampSharp.V2
     /// </summary>
     public class DefaultWampHost : WampHost
     {
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="DefaultWampHost"/> listening at
+        /// the given location with the given bindings and the given
+        /// <see cref="IWampRealmContainer"/>.
+        /// </summary>
+        /// <param name="location">The given location.</param>
+        public DefaultWampHost(string location)
+            : this(location: location, supportDualStack: true)
+        {
+        }
+
         /// <summary>
         /// Initializes a new instance of <see cref="DefaultWampHost"/> listening at
         /// the given location with the given bindings and the given


### PR DESCRIPTION
After testing we saw that the creation of the `Host` was crashing because the `FleckWebSocketTransport` cannot create the web socket if we cannot support the dual stack.

In a first time we believe that we could call the `RegisterTransport` after the creation of the `Host` but an exception was thrown when we create the object. So we need to give directly the `supportDualStack` information in the `Host` creation.

This PR follow the #289 and fix definitively the dual stack support.