### PR TITLE
Drop log level of aborted websocket exception thrown when closing websocket

### DIFF
--- a/src/net45/Extensions/WampSharp.WebSockets/WebSockets/WebSocketWrapperConnection.cs
+++ b/src/net45/Extensions/WampSharp.WebSockets/WebSockets/WebSocketWrapperConnection.cs
@@ -134,6 +134,10 @@ namespace WampSharp.WebSockets
                                             CancellationToken.None)
                                 .ConfigureAwait(false);
             }
+            catch (WebSocketException ex) when (ex.WebSocketErrorCode == WebSocketError.InvalidState)
+            {
+                mLogger.DebugException("Failed closing the websocket as it was already aborted", ex);
+            }
             catch (Exception ex)
             {
                 mLogger.WarnException("Failed sending a close message to client", ex);


### PR DESCRIPTION
The exception can be logged quite frequently when the client wamp channel closes the websocket.  Since there is a race condition between the client & router closing their respective ends of the websocket after receiving a GOODBYE message.