### PR TITLE
Make WampSharp.V2.SubscriberRegistrationInterceptor functions virtual

### DIFF
--- a/src/net45/WampSharp/WAMP2/V2/Api/DelegatePubSub/SubscriberRegistrationInterceptor.cs
+++ b/src/net45/WampSharp/WAMP2/V2/Api/DelegatePubSub/SubscriberRegistrationInterceptor.cs
@@ -18,17 +18,17 @@ namespace WampSharp.V2
             mSubscriptionOptions = subscriptionOptions;
         }
 
-        public bool IsSubscriberHandler(MethodInfo method)
+        public virtual bool IsSubscriberHandler(MethodInfo method)
         {
             return method.IsDefined(typeof (WampTopicAttribute));
         }
 
-        public string GetTopicUri(MethodInfo method)
+        public virtual string GetTopicUri(MethodInfo method)
         {
             return method.GetCustomAttribute<WampTopicAttribute>().Topic;
         }
 
-        public SubscribeOptions GetSubscribeOptions(MethodInfo method)
+        public virtual SubscribeOptions GetSubscribeOptions(MethodInfo method)
         {
             return mSubscriptionOptions;
         }


### PR DESCRIPTION
Make functions in `WampSharp.V2.SubscriberRegistrationInterceptor`  virtual, in the same way as `PublisherRegistrationInterceptor` and other interceptors.