### PR TITLE
Extract inherited methods in `WampCalleeProxyFactory`

### DIFF
--- a/src/net45/WampSharp/WAMP2/V2/Api/CalleeProxy/WampCalleeProxyFactory.cs
+++ b/src/net45/WampSharp/WAMP2/V2/Api/CalleeProxy/WampCalleeProxyFactory.cs
@@ -1,4 +1,6 @@
 #if CASTLE
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Castle.DynamicProxy;
@@ -24,7 +26,7 @@ namespace WampSharp.V2.CalleeProxy
             };
 
             IInterceptor[] interceptors =
-                typeof (TProxy).GetMethods()
+                GetAllInterfaceMethods(typeof(TProxy))
                     .Select(method => BuildInterceptor(method, interceptor))
                     .ToArray();
 
@@ -37,6 +39,17 @@ namespace WampSharp.V2.CalleeProxy
         private IInterceptor BuildInterceptor(MethodInfo method, ICalleeProxyInterceptor interceptor)
         {
             return CalleeProxyInterceptorFactory.BuildInterceptor(method, interceptor, mHandler);
+        }
+
+        private List<MethodInfo> GetAllInterfaceMethods(Type type)
+        {
+            List<MethodInfo> methods = new List<MethodInfo>(type.GetMethods());
+            foreach (Type interf in type.GetInterfaces())
+                foreach (MethodInfo method in interf.GetMethods())
+                    if (!methods.Contains(method))
+                        methods.Add(method);
+
+            return methods;
         }
     }
 }


### PR DESCRIPTION
At the moment, when using `GetCalleeProxy<>` to create a callee proxy, the proxy does not respect any of inherited methods of the interface. As an example:

This is inconsistent because when creating a callee using `RegisterCallee<>` the inherited methods of the callee do get registered as well. Thus, when using `GetCalleeProxy<>` the inherited methods should be equally respected.

As an example,

```C#
    public interface Base
    {
        [WampProcedure("base")]
        void BaseProc();
    }

    public interface Inherited : Base
    {
        [WampProcedure("inherit")]
        void Inherit();
    }

    class Program
    {

        public const string Location = "ws://127.0.0.1:55555/";
        public const string Realm = "default_realm";

        static void Main(string[] args)
        {
            DefaultWampChannelFactory channelFactory = new DefaultWampChannelFactory();
            IWampChannel channel = channelFactory.CreateJsonChannel(Location, Realm);
            channel.Open().Wait();
            var proxy = channel.RealmProxy.Services.GetCalleeProxy<Inherited>();
            proxy.BaseProc();
        }
    }
```

Will fail on the ` proxy.BaseProc()` with a `System.NotImplementedException: 'This is a DynamicProxy2 error: There are no interceptors specified for method ...` exception.

This pull requests implements this by modifying the `WampCalleeProxyFactory` to search through all inherited interfaces of an interface. 